### PR TITLE
Use landscape logo banner

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,15 +36,8 @@
     <div class="max-w-6xl mx-auto px-4 sm:px-6">
       <div class="flex items-center justify-between py-3">
         <!-- Logo -->
-        <a href="#home" class="flex items-center gap-3 group" aria-label="Music with Melissa Home">
-          <div class="w-12 h-12 rounded-full bg-white border-2 border-[var(--navy)] grid place-content-center shadow-soft">
-            <!-- Logo image -->
-            <img src="mwmlogo.png" alt="Music with Melissa logo" width="28" height="28" />
-          </div>
-          <div class="leading-tight">
-            <div class="heading text-lg font-extrabold text-[var(--navy)] leading-5">Music with</div>
-            <div class="script text-3xl -mt-1 text-[var(--amber)] leading-6">Melissa</div>
-          </div>
+        <a href="#home" aria-label="Music with Melissa Home">
+          <img src="mwmlogo.png" alt="Music with Melissa logo" class="h-12 w-auto" />
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm font-medium">
           <a href="#program" class="hover:text-[var(--navy)]/80">Program</a>
@@ -83,10 +76,8 @@
           <div class="absolute -inset-4 rounded-3xl bg-white/60 blur-xl"></div>
           <div class="relative rounded-3xl border border-slate-200 bg-white p-6 shadow-soft animate-float">
             <div class="aspect-[16/10] rounded-2xl bg-gradient-to-br from-[var(--cream)] to-white grid place-content-center">
-              <!-- Decorative large logo badge -->
-              <div class="w-40 h-40 rounded-full bg-white border-4 border-[var(--navy)] grid place-content-center mx-auto">
-                <img src="mwmlogo.png" alt="Music with Melissa logo" width="90" height="90" />
-              </div>
+              <!-- Decorative logo banner -->
+              <img src="mwmlogo.png" alt="Music with Melissa logo" class="w-40 h-auto mx-auto" />
               <p class="text-center mt-6 text-slate-700 px-6">“All are welcome. Every voice matters.”</p>
             </div>
             <ul class="mt-6 grid sm:grid-cols-2 gap-3 text-sm">


### PR DESCRIPTION
## Summary
- Show logo as a horizontal banner in the header instead of a circular badge.
- Remove redundant header text now that the logo contains the business name.
- Update hero section to feature the logo banner rather than a circular badge.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b50b38c2588331858f7d2ad2d9ca21