### PR TITLE
Add Express backend with contact endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your_username
+SMTP_PASS=your_password
+CONTACT_EMAIL=recipient@example.com

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.env

--- a/index.html
+++ b/index.html
@@ -332,12 +332,33 @@
   </footer>
 
   <script>
-    // Basic in-page form handler (no backend)
+    // Submit form to backend
     function handleSubmit(e){
       e.preventDefault();
+      const form = e.target;
       const status = document.getElementById('formStatus');
-      status.textContent = 'Thanks! We received your inquiry and will follow up shortly.';
-      e.target.reset();
+      const formData = {
+        name: form.name.value,
+        email: form.email.value,
+        role: form.role.value,
+        phone: form.phone.value,
+        community: form.community.value,
+        message: form.message.value,
+        mc: form.mc.checked
+      };
+      fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(formData)
+      }).then(resp => {
+        if(!resp.ok) throw new Error('Request failed');
+        return resp.json();
+      }).then(data => {
+        status.textContent = 'Thanks! We received your inquiry and will follow up shortly.';
+        form.reset();
+      }).catch(() => {
+        status.textContent = 'Sorry, there was a problem. Please try again later.';
+      });
       return false;
     }
     document.getElementById('year').textContent = new Date().getFullYear();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mwm",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "dotenv": "^16.4.1",
+    "express": "^4.18.2",
+    "nodemailer": "^6.9.8"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,44 @@
+const express = require('express');
+const nodemailer = require('nodemailer');
+const dotenv = require('dotenv');
+
+dotenv.config();
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.use(express.json());
+app.use(express.static(__dirname));
+
+const transporter = nodemailer.createTransport({
+  host: process.env.SMTP_HOST,
+  port: parseInt(process.env.SMTP_PORT, 10) || 587,
+  secure: parseInt(process.env.SMTP_PORT, 10) === 465,
+  auth: {
+    user: process.env.SMTP_USER,
+    pass: process.env.SMTP_PASS,
+  },
+});
+
+app.post('/api/contact', async (req, res) => {
+  const { name, email, role, phone, community, message, mc } = req.body;
+
+  const text = `Name: ${name}\nEmail: ${email}\nRole: ${role}\nPhone: ${phone}\nCommunity: ${community}\nInterested in MC: ${mc ? 'Yes' : 'No'}\nMessage: ${message}`;
+
+  try {
+    await transporter.sendMail({
+      from: process.env.SMTP_USER,
+      to: process.env.CONTACT_EMAIL,
+      subject: 'New Contact Form Submission',
+      text,
+    });
+    res.json({ success: true });
+  } catch (error) {
+    console.error('Email sending failed:', error);
+    res.status(500).json({ success: false });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- build Express server with nodemailer-powered `/api/contact` endpoint and environment-based SMTP credentials
- wire frontend form to post to backend and handle success or failure
- add Node project files and ignore `.env`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `node server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68b51218f8388331b4c1e942c5d0a1f0