### PR TITLE
Add READMSG command with reply button

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,6 +327,14 @@
     </div>
   </section>
 
+  <!-- Messages -->
+  <section id="messages" class="py-16 sm:py-24 bg-white">
+    <div class="max-w-3xl mx-auto px-4 sm:px-6">
+      <h2 class="heading text-3xl font-extrabold text-[var(--navy)]">Messages</h2>
+      <div id="messageContainer" class="mt-4"></div>
+    </div>
+  </section>
+
   <!-- Footer -->
   <footer class="py-10 border-t border-slate-200 bg-[var(--cream)]">
     <div class="max-w-6xl mx-auto px-4 sm:px-6 text-sm text-slate-600 flex flex-col sm:flex-row items-center justify-between gap-4">
@@ -378,6 +386,40 @@
       learnMoreBtn.addEventListener('click', () => {
         promoModal.classList.add('hidden');
       });
+    }
+
+    // Display a message and include a button to reply
+    async function READMSG(id) {
+      const container = document.getElementById('messageContainer');
+      container.textContent = 'Loading...';
+      try {
+        const resp = await fetch(`/api/messages/${id}`);
+        if (!resp.ok) throw new Error('Not found');
+        const msg = await resp.json();
+        container.innerHTML = `\
+<p>${msg.text}</p>\
+<button id="replyBtn" class="mt-2 px-4 py-2 rounded-xl bg-[var(--amber)] text-white hover:opacity-90 transition">Reply</button>`;
+        document.getElementById('replyBtn').addEventListener('click', () => REPLYMSG(id));
+      } catch (err) {
+        container.textContent = 'Unable to load message.';
+      }
+    }
+
+    // REPLYMSG command invoked by the reply button
+    async function REPLYMSG(id) {
+      const reply = prompt('Enter your reply:');
+      if (reply === null) return;
+      try {
+        const resp = await fetch(`/api/messages/${id}/reply`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ reply }),
+        });
+        if (!resp.ok) throw new Error('Request failed');
+        alert('Reply sent!');
+      } catch (err) {
+        alert('Unable to send reply.');
+      }
     }
   </script>
 </body>

--- a/server.js
+++ b/server.js
@@ -20,6 +20,31 @@ const transporter = nodemailer.createTransport({
   },
 });
 
+// In-memory messages for demonstration purposes
+const messages = [
+  { id: 1, text: 'Welcome to Music with Melissa!' },
+  { id: 2, text: 'This is your second message.' },
+];
+
+// READMSG command: return a message by id
+app.get('/api/messages/:id', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const msg = messages.find((m) => m.id === id);
+  if (msg) {
+    res.json(msg);
+  } else {
+    res.status(404).json({ error: 'Message not found' });
+  }
+});
+
+// REPLYMSG command: handle replies to a message
+app.post('/api/messages/:id/reply', (req, res) => {
+  const id = parseInt(req.params.id, 10);
+  const { reply } = req.body;
+  console.log(`Reply to message ${id}: ${reply}`);
+  res.json({ success: true });
+});
+
 app.post('/api/contact', async (req, res) => {
   const { name, email, role, phone, community, message, mc } = req.body;
 


### PR DESCRIPTION
## Summary
- introduce READMSG API endpoint and in-memory message store
- add REPLYMSG endpoint and client functions with reply button

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b5b1b37570833192d0ed1edffe6cb2